### PR TITLE
Resolve testing issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,5 @@ strict = 1
 restructuredtext = 1
 
 [flake8]
-ignore=_
+ignore = W504
 copyright-check = True

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ classifiers = [
 requires = ['blockdiag>=1.5.0']
 test_requires = ['nose',
                  'pep8>=1.3',
+                 'flake8',
+                 'flake8-coding',
+                 'flake8-copyright',
                  'reportlab',
                  'docutils']
 

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,6 @@ test_requires = ['nose',
                  'reportlab',
                  'docutils']
 
-# only for Python2.6
-if sys.version_info > (2, 6) and sys.version_info < (2, 7):
-    test_requires.append('unittest2')
-
 if (3, 2) < sys.version_info < (3, 3):
     requires.append('webcolors < 1.5')  # webcolors-1.5 does not support py32
 

--- a/src/nwdiag/elements.py
+++ b/src/nwdiag/elements.py
@@ -36,7 +36,7 @@ class DiagramNode(blockdiag.elements.DiagramNode):
 
         for attr in attrs:
             if attr.name == 'address':
-                address = re.sub('\s*,\s*', '\n', unquote(attr.value))
+                address = re.sub(r'\s*,\s*', '\n', unquote(attr.value))
                 self.address[network] = address
             else:
                 self.set_attribute(attr)

--- a/src/nwdiag/tests/test_rst_directives.py
+++ b/src/nwdiag/tests/test_rst_directives.py
@@ -152,7 +152,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, '<svg height="\d+" width="\d+" ')
+        self.assertRegexpMatches(svg, r'<svg height="\d+" width="\d+" ')
 
     def test_setup_noviewbox_is_false(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, noviewbox=False)
@@ -166,7 +166,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, '<svg viewBox="0 0 \d+ \d+" ')
+        self.assertRegexpMatches(svg, r'<svg viewBox="0 0 \d+ \d+" ')
 
     def test_setup_inline_svg_is_true(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, inline_svg=True)
@@ -238,7 +238,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="\d+" width="100" ')
+                                 r'<svg height="\d+" width="100" ')
 
     def test_setup_inline_svg_is_true_and_width_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -255,7 +255,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="\d+" width="10000" ')
+                                 r'<svg height="\d+" width="10000" ')
 
     def test_setup_inline_svg_is_true_and_height_option1(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -272,7 +272,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="100" width="\d+" ')
+                                 r'<svg height="100" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_height_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -289,7 +289,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="10000" width="\d+" ')
+                                 r'<svg height="10000" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_width_and_height_option(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,

--- a/src/packetdiag/tests/test_rst_directives.py
+++ b/src/packetdiag/tests/test_rst_directives.py
@@ -140,7 +140,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, '<svg height="\d+" width="\d+" ')
+        self.assertRegexpMatches(svg, r'<svg height="\d+" width="\d+" ')
 
     def test_setup_noviewbox_is_false(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, noviewbox=False)
@@ -152,7 +152,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, '<svg viewBox="0 0 \d+ \d+" ')
+        self.assertRegexpMatches(svg, r'<svg viewBox="0 0 \d+ \d+" ')
 
     def test_setup_inline_svg_is_true(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, inline_svg=True)
@@ -214,7 +214,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="\d+" width="100" ')
+                                 r'<svg height="\d+" width="100" ')
 
     def test_setup_inline_svg_is_true_and_width_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -229,7 +229,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="\d+" width="10000" ')
+                                 r'<svg height="\d+" width="10000" ')
 
     def test_setup_inline_svg_is_true_and_height_option1(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -244,7 +244,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="100" width="\d+" ')
+                                 r'<svg height="100" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_height_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -259,7 +259,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="10000" width="\d+" ')
+                                 r'<svg height="10000" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_width_and_height_option(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,

--- a/src/rackdiag/elements.py
+++ b/src/rackdiag/elements.py
@@ -67,11 +67,11 @@ class RackItem(blockdiag.elements.DiagramNode):
         return u("\n").join(labels)
 
     def set_attribute(self, attr):
-        if re.search('^\d+U$', attr.name):
+        if re.search(r'^\d+U$', attr.name):
             self.colheight = int(attr.name[:-1])
-        elif re.search('^\d+(\.[0-9]+)?A$', attr.name):
+        elif re.search(r'^\d+(\.[0-9]+)?A$', attr.name):
             self.ampere = float(attr.name[:-1])
-        elif re.search('^\d+(\.[0-9]+)?kg$', attr.name):
+        elif re.search(r'^\d+(\.[0-9]+)?kg$', attr.name):
             self.weight = float(attr.name[:-2])
         else:
             return super(RackItem, self).set_attribute(attr)
@@ -199,7 +199,7 @@ class Rack(blockdiag.elements.NodeGroup):
         self.descending = False
 
     def set_attribute(self, attr):
-        if re.search('^\d+U$', attr.name):
+        if re.search(r'^\d+U$', attr.name):
             self.colheight = int(attr.name[:-1])
         else:
             return super(Rack, self).set_attribute(attr)

--- a/src/rackdiag/elements.py
+++ b/src/rackdiag/elements.py
@@ -140,7 +140,7 @@ class Rack(blockdiag.elements.NodeGroup):
         def get_max_height(self, y):
             try:
                 return max(n.colheight for n in self.items(y))
-            except:
+            except Exception:
                 return 0
 
         height = get_max_height(self, level)

--- a/src/rackdiag/tests/test_rst_directives.py
+++ b/src/rackdiag/tests/test_rst_directives.py
@@ -140,7 +140,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, '<svg height="\d+" width="\d+" ')
+        self.assertRegexpMatches(svg, r'<svg height="\d+" width="\d+" ')
 
     def test_setup_noviewbox_is_false(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, noviewbox=False)
@@ -152,7 +152,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, '<svg viewBox="0 0 \d+ \d+" ')
+        self.assertRegexpMatches(svg, r'<svg viewBox="0 0 \d+ \d+" ')
 
     def test_setup_inline_svg_is_true(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, inline_svg=True)
@@ -214,7 +214,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="\d+" width="100" ')
+                                 r'<svg height="\d+" width="100" ')
 
     def test_setup_inline_svg_is_true_and_width_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -229,7 +229,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="\d+" width="10000" ')
+                                 r'<svg height="\d+" width="10000" ')
 
     def test_setup_inline_svg_is_true_and_height_option1(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -244,7 +244,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="100" width="\d+" ')
+                                 r'<svg height="100" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_height_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -259,7 +259,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
         self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="10000" width="\d+" ')
+                                 r'<svg height="10000" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_width_and_height_option(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,blockdiag_dev
+envlist=py27,py32,py33,py34,blockdiag_dev
 
 [testenv]
 deps=
@@ -15,14 +15,6 @@ commands=
     nosetests
     flake8 src
 
-
-[testenv:py26]
-deps=
-    nose
-    flake8
-    docutils
-    reportlab
-    unittest2
 
 [testenv:blockdiag_dev]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ commands=
 [testenv:blockdiag_dev]
 deps=
     {[testenv]deps}
-    hg+https://bitbucket.org/blockdiag/blockdiag
+    git+https://github.com/blockdiag/blockdiag.git

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 envlist=py27,py32,py33,py34,blockdiag_dev
 
 [testenv]
+usedevelop = True
+extras =
+    pdf
+    rst
+    testing
 deps=
-    nose
-    flake8
-    flake8-coding
-    flake8-copyright
-    docutils
-    reportlab
 passenv=
     ALL_TESTS
 commands=


### PR DESCRIPTION
This series resolves issues at testing below:

- errors/warning with recent flake8
- dependency configuration around setup.py/tox.ini

Unfortunately, some failures below occur even after this series.

- "images do not match" failure with recetn Pillow (will be resolved by pull request https://github.com/blockdiag/blockdiag/pull/109 to blockdiag)
- "new style getargs format but argument is not a tuple" failure (will be resolved by the last commit in pull request #15  to nwdiag)
