### PR TITLE
Drop py36 support and add py39 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: '3.5'
-            toxenv: py35
-          - python-version: '3.6'
-            toxenv: py36
           - python-version: '3.7'
             toxenv: py37
           - python-version: '3.8'
             toxenv: py38
-          - python-version: '3.8'
+          - python-version: '3.9'
+            toxenv: py39
+          - python-version: '3.9'
             toxenv: blockdiag_dev
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Execute nwdiag command::
 
 Requirements
 ============
-* Python 3.5 or later
+* Python 3.7 or later
 * blockdiag 1.5.0 or later
 * funcparserlib 0.3.6 or later
 * reportlab (optional)

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,9 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Software Development",
     "Topic :: Software Development :: Documentation",
     "Topic :: Text Processing :: Markup",
@@ -56,6 +55,7 @@ setup(
     package_dir={'': 'src'},
     package_data={'': ['buildout.cfg']},
     include_package_data=True,
+    python_requires=">=3.7",
     install_requires=['blockdiag>=1.5.0'],
     extras_require=dict(
         testing=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
-envlist=py35,py36,py37,py38,blockdiag_dev
+envlist=py37,py38,py39,blockdiag_dev
 
 [testenv]
 usedevelop = True
-deps =
-    py35: funcparserlib < 1.0
 # for funcparserlib-1.0.0a0
 pip_pre = True
 extras =


### PR DESCRIPTION
Almost 3 weeks later, since 2021/12/23, python 3.6 will become EOL.
So it's time to drop py36 support. Instead of it, this adds python 3.9
support.