### PR TITLE
Feature/link color style

### DIFF
--- a/src/nwdiag/drawer.py
+++ b/src/nwdiag/drawer.py
@@ -149,11 +149,19 @@ class DiagramDraw(blockdiag.drawer.DiagramDraw):
         m = self.metrics
 
         for connector in m.node(node).connectors:
-            self.draw_connector(connector)
             if hasattr(connector, 'subject'):
                 network = connector.subject.network
             else:
                 network = connector.network
+
+            linestyle=None
+            if network in node.linestyles:
+                linestyle=node.linestyles[network]
+            linecolor=None
+            if network in node.linecolors:
+                linecolor=node.linecolors[network]
+
+            self.draw_connector(connector,linestyle,linecolor)
 
             if network in node.address:
                 label = node.address[network]
@@ -163,12 +171,17 @@ class DiagramDraw(blockdiag.drawer.DiagramDraw):
 
         super(DiagramDraw, self).node(node, **kwargs)
 
-    def draw_connector(self, connector):
+    def draw_connector(self, connector, linestyle, linecolor):
         if hasattr(connector, 'subject'):
-            linecolor = connector.subject.network.linecolor
+            lc = connector.subject.network.linecolor
+            ls = connector.subject.network.linestyle
         else:
-            linecolor = connector.network.linecolor
-        self.drawer.line(connector.line, fill=linecolor, jump=True)
+            lc = connector.network.linecolor
+            ls = connector.network.linestyle
+        if linestyle is None: linestyle=ls
+        if linecolor is None: linecolor=lc
+
+        self.drawer.line(connector.line, fill=linecolor, style=linestyle, jump=True)
 
     def group_label(self, group):
         if group.label:

--- a/src/nwdiag/elements.py
+++ b/src/nwdiag/elements.py
@@ -28,6 +28,8 @@ class DiagramNode(blockdiag.elements.DiagramNode):
         super(DiagramNode, self).__init__(_id)
 
         self.address = {}
+        self.linestyles = {}
+        self.linecolors = {}
         self.networks = []
         self.layouted = False
 
@@ -39,6 +41,12 @@ class DiagramNode(blockdiag.elements.DiagramNode):
             if attr.name == 'address':
                 address = re.sub(r'\s*,\s*', '\n', unquote(attr.value))
                 self.address[network] = address
+            elif attr.name == 'linestyle':
+                style = re.sub(r'\s*,\s*', '\n', unquote(attr.value))
+                self.linestyles[network] = style
+            elif attr.name == 'linecolor':
+                color = re.sub(r'\s*,\s*', '\n', unquote(attr.value))
+                self.linecolors[network] = color
             else:
                 self.set_attribute(attr)
 
@@ -50,6 +58,7 @@ class DiagramEdge(blockdiag.elements.DiagramEdge):
 class Network(blockdiag.elements.NodeGroup):
     basecolor = (185, 203, 228)
     linecolor = (0, 0, 0)
+    linestyle = "solid"
 
     @classmethod
     def set_default_linecolor(cls, color):

--- a/src/nwdiag/metrics.py
+++ b/src/nwdiag/metrics.py
@@ -159,7 +159,7 @@ class GroupMetrics(blockdiag.metrics.NodeMetrics):
         if group.nodes:
             networks = group.nodes[0].networks[:]
             networks.sort(key=lambda a: a.xy.y)
-            network = min(networks)
+            network = networks[0]
             if self.top.x == metrics.network(network).top.x:
                 self.is_root_group = True
 


### PR DESCRIPTION
Adds linecolor and linestyle in addition to addresses in nwdiag.
Aim: allow to draw a dashed or different coloured network connection e.g. to indicate a "unplugged" cable